### PR TITLE
FasterImage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,10 @@
         {
             "name": "Garrett St. John",
             "email": "gstjohn@gmail.com"
+        },
+        {
+          "name": "Will Washburn",
+          "email": "will.washburn@gmail.com"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "require": {
         "webignition/absolute-url-deriver": "~1.5",
         "gstjohn/fastimage": "~1.0"
+        "fasterimage/fasterimage": "0.0.4"
     },
     "require-dev": {
         "phpspec/phpspec": "~2.0@dev"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "webignition/absolute-url-deriver": "~1.5",
         "gstjohn/fastimage": "~1.0",
-        "fasterimage/fasterimage": "0.0.4"
+        "fasterimage/fasterimage": "~1.0"
     },
     "require-dev": {
         "phpspec/phpspec": "~2.0@dev"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "webignition/absolute-url-deriver": "~1.5",
-        "gstjohn/fastimage": "~1.0"
+        "gstjohn/fastimage": "~1.0",
         "fasterimage/fasterimage": "0.0.4"
     },
     "require-dev": {

--- a/examples/basic.php
+++ b/examples/basic.php
@@ -13,7 +13,7 @@ $html = file_get_contents($url);
 $doc = new DOMDocument();
 $doc->loadHTML($html);
 
-$analyzer = new FastImageAnalyzer(new FastImage());
+$analyzer = new \Thumbsnag\FasterImageAnalyzer(new \FasterImage\FasterImage());
 
 $thumbsnag = Thumbsnag::load(new UrlDocument($doc, $url), $analyzer);
 $images = $thumbsnag->process();

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ Thumbsnag crawls an HTML document and finds imagery that best represents the giv
 ## Example
 
 ```php
-use Thumbsnag\FastImageAnalyzer;
+use Thumbsnag\FasterImageAnalyzer;
 use Thumbsnag\Thumbsnag;
 use Thumbsnag\UrlDocument;
 
@@ -15,7 +15,7 @@ $html = file_get_contents($url);
 $document = new DOMDocument();
 $document->loadHTML($html);
 
-$analyzer = new FastImageAnalyzer(new FastImage());
+$analyzer = new FasterImageAnalyzer(new \FasterImage\FasterImage());
 
 $thumbsnag = Thumbsnag::load(new UrlDocument($doc, $url), $analyzer);
 $images = $thumbsnag->process();

--- a/spec/ThumbsnagSpec.php
+++ b/spec/ThumbsnagSpec.php
@@ -64,28 +64,36 @@ class ThumbsnagSpec extends ObjectBehavior
 
 class StubFileSizeAnalyzer implements ImageSizeAnalyzer
 {
-
-    private $filePath;
-
-    /**
-     * Load URL
-     *
-     * @param $url
-     */
-    public function load($url)
-    {
-        $this->filePath = __DIR__ . '/../stub/img/' . basename($url);
-    }
-
     /**
      * Get image size
      *
      * @return array
      */
-    public function getSize()
+    private function getSize($url)
     {
-        $imageSize = getimagesize($this->filePath);
+        $imageSize = @getimagesize(__DIR__ . '/../stub/img/' . basename($url));
 
-        return [$imageSize[0], $imageSize[1]];
+        if (!empty($imageSize)) {
+            return [current($imageSize), next($imageSize)];
+        }
+
+        return 'failed';
+    }
+
+    /**
+     * Get the sizes of a given array of image urls
+     *
+     * @param array $urls
+     *
+     * @return mixed
+     */
+    public function batch(array $urls)
+    {
+        $sizes = [];
+        foreach ($urls as $url) {
+            $sizes[$url]['size'] = $this->getSize($url);
+        }
+
+        return $sizes;
     }
 }

--- a/src/FastImageAnalyzer.php
+++ b/src/FastImageAnalyzer.php
@@ -18,14 +18,21 @@ class FastImageAnalyzer implements ImageSizeAnalyzer
     }
 
     /**
-     * Load URL
+     * Get the sizes of a given array of image urls
      *
-     * @param $url
+     * @param array $urls
+     *
+     * @return mixed
      */
-    public function load($url)
+    public function batch(array $urls)
     {
-        $this->analyzer = new $this->fastImage;
-        $this->analyzer->load($url);
+        $results = [];
+        foreach ($urls as $url) {
+            $this->load($url);
+            $results[$url]['size'] = $this->getSize();
+        }
+
+        return $results;
     }
 
     /**
@@ -34,7 +41,7 @@ class FastImageAnalyzer implements ImageSizeAnalyzer
      * @return array
      * @throws \Exception
      */
-    public function getSize()
+    protected function getSize()
     {
         $result = $this->analyzer->getSize();
 
@@ -44,5 +51,16 @@ class FastImageAnalyzer implements ImageSizeAnalyzer
         }
 
         return $result;
+    }
+
+    /**
+     * Load URL
+     *
+     * @param $url
+     */
+    protected function load($url)
+    {
+        $this->analyzer = new $this->fastImage;
+        $this->analyzer->load($url);
     }
 }

--- a/src/FasterImageAnalyzer.php
+++ b/src/FasterImageAnalyzer.php
@@ -1,0 +1,27 @@
+<?php namespace Thumbsnag;
+
+class FasterImageAnalyzer implements ImageSizeAnalyzer
+{
+    /**
+     * @var \FasterImage\FasterImage
+     */
+    private $fasterImage;
+
+
+    public function __construct(\FasterImage\FasterImage $fasterimage)
+    {
+        $this->fasterImage = $fasterimage;
+    }
+
+    /**
+     * Get the sizes of a given array of image urls
+     *
+     * @param array $urls
+     *
+     * @return mixed
+     */
+    public function batch(array $urls)
+    {
+        return $this->fasterImage->batch($urls);
+    }
+}

--- a/src/ImageSizeAnalyzer.php
+++ b/src/ImageSizeAnalyzer.php
@@ -1,20 +1,13 @@
-<?php
-
-namespace Thumbsnag;
+<?php namespace Thumbsnag;
 
 interface ImageSizeAnalyzer {
 
     /**
-     * Load URL
+     * Get the sizes of a given array of image urls
      *
-     * @param $url
-     */
-    public function load($url);
-
-    /**
-     * Get image size
+     * @param array $urls
      *
-     * @return array
+     * @return mixed
      */
-    public function getSize();
+    public function batch(array $urls);
 }


### PR DESCRIPTION
Hey @gstjohn !

Cool library! Are you using this at any kind of scale?

I ended up rewriting our FastImage implementation into a new library called [FasterImage](https://github.com/willwashburn/FasterImage/tree/master) ( I know, super original name)

Anyway, instead of using fopen streams (original fastimage) or "curl ranges" (fastimage branch I had, which I believe you forked) this  is using curl_multi\* and actually streaming the data. 

The result is that the requests take less time if you're doing them in batches. Since most pages will have more than one image, I thought it'd be cool to integrate this into your library!

I also added support for .tiff images (in FasterImage) and plan to support it going forward best I can.

 Let me know if I can help in any other way!

-- wash
